### PR TITLE
Feat/error_response

### DIFF
--- a/src/main/kotlin/ecommerce/advice/ApiErrorControllerAdvice.kt
+++ b/src/main/kotlin/ecommerce/advice/ApiErrorControllerAdvice.kt
@@ -1,5 +1,7 @@
 package ecommerce.advice
 
+import ecommerce.dto.error.ErrorMessage
+import ecommerce.dto.error.ErrorResponse
 import ecommerce.exception.AuthorizationException
 import ecommerce.exception.ForbiddenException
 import ecommerce.exception.InsufficientStockException
@@ -26,243 +28,138 @@ import java.time.Instant
 class ApiErrorControllerAdvice {
     private val log = logger<ApiErrorControllerAdvice>()
 
-    /**
-     * Custom Exceptions
-     */
+    private fun buildErrorResponse(
+        status: HttpStatus,
+        errorLabel: String,
+        message: String,
+        errors: List<ErrorMessage>? = null,
+    ): ResponseEntity<ErrorResponse> {
+        val body =
+            ErrorResponse(
+                status = status.value(),
+                errorLabel = errorLabel,
+                message = message,
+                errors = errors,
+                timestamp = Instant.now(),
+            )
+        return ResponseEntity.status(status).body(body)
+    }
+
     @ExceptionHandler(NotFoundException::class)
-    fun handleNotFoundException(e: NotFoundException): ResponseEntity<Map<String, Any>> {
+    fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Not Found error"
         log.warn("NotFoundException occurred: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.NOT_FOUND.value(),
-                "error" to "Operation failed",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body)
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Operation failed", errorMessage)
     }
 
     @ExceptionHandler(NoSuchElementException::class)
-    fun handleNotSuchElementException(e: NoSuchElementException): ResponseEntity<Map<String, Any>> {
+    fun handleNotSuchElementException(e: NoSuchElementException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Not such element"
-        log.error("NoSuchElementException occurred: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.NOT_FOUND.value(),
-                "error" to "Operation failed",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body)
+        log.warn("NoSuchElementException occurred: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Operation failed", errorMessage)
     }
 
     @ExceptionHandler(OperationFailedException::class)
-    fun handleOperationFailedException(e: OperationFailedException): ResponseEntity<Map<String, Any>> {
+    fun handleOperationFailedException(e: OperationFailedException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Operation failed"
-        log.error("OperationFailedException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Operation failed",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        log.warn("OperationFailedException: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Operation failed", errorMessage)
     }
 
     @ExceptionHandler(AuthorizationException::class)
-    fun handleAuthorizationException(e: AuthorizationException): ResponseEntity<Map<String, Any>> {
+    fun handleAuthorizationException(e: AuthorizationException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Authorization failed"
         log.warn("AuthorizationException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.UNAUTHORIZED.value(),
-                "error" to "Authorization failed",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body)
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, "Authorization failed", errorMessage)
     }
 
     @ExceptionHandler(ForbiddenException::class)
-    fun handleForbiddenException(e: ForbiddenException): ResponseEntity<Map<String, Any>> {
+    fun handleForbiddenException(e: ForbiddenException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Invalid credentials"
         log.warn("ForbiddenException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.FORBIDDEN.value(),
-                "error" to "Authorization failed. Invalid Credentials",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body)
+        return buildErrorResponse(HttpStatus.FORBIDDEN, "Authorization failed. Invalid Credentials", errorMessage)
     }
 
     @ExceptionHandler(InvalidCartItemQuantityException::class)
-    fun handleInvalidCartItemQuantityException(e: InvalidCartItemQuantityException): ResponseEntity<Map<String, Any>> {
+    fun handleInvalidCartItemQuantityException(e: InvalidCartItemQuantityException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Invalid quantity"
         log.warn("InvalidCartItemQuantityException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Invalid cart item quantity",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Invalid cart item quantity", errorMessage)
     }
 
     @ExceptionHandler(InvalidOptionNameException::class)
-    fun handleInvalidOptionNameException(e: InvalidOptionNameException): ResponseEntity<Map<String, Any>> {
+    fun handleInvalidOptionNameException(e: InvalidOptionNameException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Invalid option name"
         log.warn("InvalidOptionNameException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Invalid option name",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Invalid option name", errorMessage)
     }
 
     @ExceptionHandler(InvalidOptionQuantityException::class)
-    fun handleInvalidOptionQuantityException(e: InvalidOptionQuantityException): ResponseEntity<Map<String, Any>> {
+    fun handleInvalidOptionQuantityException(e: InvalidOptionQuantityException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Invalid option quantity"
         log.warn("InvalidOptionQuantityException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Invalid option quantity",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Invalid option quantity", errorMessage)
     }
 
     @ExceptionHandler(InsufficientStockException::class)
-    fun handleInsufficientStockException(e: InsufficientStockException): ResponseEntity<Map<String, Any>> {
+    fun handleInsufficientStockException(e: InsufficientStockException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Insufficient stock"
         log.warn("InsufficientStockException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.CONFLICT.value(),
-                "error" to "Insufficient stock",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(body)
+        return buildErrorResponse(HttpStatus.CONFLICT, "Insufficient stock", errorMessage)
     }
 
     @ExceptionHandler(PaymentFailedException::class)
-    fun handlePaymentFailedException(e: PaymentFailedException): ResponseEntity<Map<String, Any>> {
+    fun handlePaymentFailedException(e: PaymentFailedException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Payment failed"
-        log.error("PaymentFailedException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Payment failed",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        log.warn("PaymentFailedException: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Payment failed", errorMessage)
     }
 
-    /**
-     * Resource Access Exceptions: e.g., timeouts
-     */
     @ExceptionHandler(ResourceAccessException::class)
-    fun handleResourceAccessException(e: ResourceAccessException): ResponseEntity<Map<String, Any>> {
+    fun handleResourceAccessException(e: ResourceAccessException): ResponseEntity<ErrorResponse> {
         val errorMessage = "Request timed out"
         log.error("ResourceAccessException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.GATEWAY_TIMEOUT.value(),
-                "error" to "Request Timeout",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT).body(body)
+        return buildErrorResponse(HttpStatus.GATEWAY_TIMEOUT, "Request Timeout", errorMessage)
     }
 
-    /**
-     * Fallback handler for all uncaught exceptions
-     */
     @ExceptionHandler(Exception::class)
-    fun handleGenericException(e: Exception): ResponseEntity<Map<String, Any>> {
+    fun handleGenericException(e: Exception): ResponseEntity<ErrorResponse> {
+        val errorMessage = e.message ?: "Generic error"
         log.error("Unhandled exception occurred: ${e.message}", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                "error" to "Internal Server Error",
-                "message" to "An unexpected error occurred",
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body)
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", errorMessage)
     }
 
-    /**
-     * JDBC Exceptions: DB errors
-     */
     @ExceptionHandler(DataAccessException::class)
-    fun handleDataAccessException(e: DataAccessException): ResponseEntity<Map<String, Any>> {
+    fun handleDataAccessException(e: DataAccessException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Data Access Error"
         log.error("DataAccessException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.INTERNAL_SERVER_ERROR.value(),
-                "error" to "Empty result data access error",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body)
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Empty result data access error", errorMessage)
     }
 
     @ExceptionHandler(DuplicateKeyException::class)
-    fun handleDuplicateKeyException(e: DuplicateKeyException): ResponseEntity<Map<String, Any>> {
+    fun handleDuplicateKeyException(e: DuplicateKeyException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Duplicate key error"
         log.warn("DuplicateKeyException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.CONFLICT.value(),
-                "error" to "Duplicate Key Error",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(body)
+        return buildErrorResponse(HttpStatus.CONFLICT, "Duplicate Key Error", errorMessage)
     }
 
     @ExceptionHandler(EmptyResultDataAccessException::class)
-    fun handleEmptyResultException(e: EmptyResultDataAccessException): ResponseEntity<Map<String, Any>> {
+    fun handleEmptyResultException(e: EmptyResultDataAccessException): ResponseEntity<ErrorResponse> {
         val errorMessage = e.message ?: "Empty result for your query"
-        log.error("EmptyResultDataAccessException: $errorMessage", e)
-        val body =
-            mapOf(
-                "status" to HttpStatus.NOT_FOUND.value(),
-                "error" to "Empty Result Data Access",
-                "message" to errorMessage,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body)
+        log.warn("EmptyResultDataAccessException: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.NOT_FOUND, "Empty Result Data Access", errorMessage)
     }
 
-    /**
-     * @Valid Exceptions, thrown when validation using jakarta fails.
-     */
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<Map<String, Any>> {
+    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val errorMessage = e.message
         log.warn("Validation failed: ${e.message}")
 
-        val errors = e.bindingResult.fieldErrors.associate { it.field to (it.defaultMessage ?: "Validation error") }
+        val errors =
+            e.bindingResult.fieldErrors.map {
+                ErrorMessage(it.field, it.defaultMessage ?: "Validation error")
+            }
 
-        val body =
-            mapOf(
-                "status" to HttpStatus.BAD_REQUEST.value(),
-                "error" to "Validation failed",
-                "message" to errors,
-                "timestamp" to Instant.now(),
-            )
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body)
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed", errorMessage, errors = errors)
     }
 }

--- a/src/main/kotlin/ecommerce/dto/error/ErrorMessage.kt
+++ b/src/main/kotlin/ecommerce/dto/error/ErrorMessage.kt
@@ -1,0 +1,3 @@
+package ecommerce.dto.error
+
+data class ErrorMessage(val field: String, val message: String)

--- a/src/main/kotlin/ecommerce/dto/error/ErrorResponse.kt
+++ b/src/main/kotlin/ecommerce/dto/error/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package ecommerce.dto.error
+
+import java.time.Instant
+
+data class ErrorResponse(
+    val status: Int,
+    val errorLabel: String,
+    val message: Any,
+    val timestamp: Instant,
+    val errors: List<ErrorMessage>? = null,
+)


### PR DESCRIPTION
# BASS APP

## Summary
Refactored the API error handling logic to use a centralized and structured error responses. Introduced reusable error response models for all exception handlers.

## Changes
- Created `ErrorResponse` and `ErrorMessage` DTOs
- Replaced repeated `Map<String, Any>` error bodies with `ErrorResponse`
- Updated `ApiErrorControllerAdvice` to:
  - Use `buildErrorResponse()` across all exception handlers
  - Improve logging levels based on exception type (warn/error)

## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated (or not required)
- [x] Documentation updated (where applicable)
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
#3 
