### PR TITLE
Feat/create tag module

### DIFF
--- a/src/main/kotlin/bass/controller/tag/TagController.kt
+++ b/src/main/kotlin/bass/controller/tag/TagController.kt
@@ -1,0 +1,25 @@
+package bass.controller.tag
+
+import bass.controller.tag.usecase.ManageTagUseCase
+import bass.dto.tag.CreateTagDTO
+import bass.dto.tag.TagDTO
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class TagController(private val manageTagUseCase: ManageTagUseCase) {
+    @GetMapping(TAGS)
+    fun getTags(): ResponseEntity<List<TagDTO>> = ResponseEntity.ok(manageTagUseCase.findAll())
+
+    @PostMapping(TAGS)
+    fun createTag(
+        @RequestBody tag: CreateTagDTO,
+    ): ResponseEntity<TagDTO> = ResponseEntity.ok(manageTagUseCase.create(tag))
+
+    companion object {
+        const val TAGS = "/api/tags"
+    }
+}

--- a/src/main/kotlin/bass/controller/tag/usecase/ManageTagUseCase.kt
+++ b/src/main/kotlin/bass/controller/tag/usecase/ManageTagUseCase.kt
@@ -1,0 +1,13 @@
+package bass.controller.tag.usecase
+
+import bass.dto.tag.CreateTagDTO
+import bass.dto.tag.TagDTO
+import bass.entities.TagEntity
+
+interface ManageTagUseCase {
+    fun findAll(): List<TagDTO>
+
+    fun findByName(name: String): TagEntity?
+
+    fun create(tag: CreateTagDTO): TagDTO
+}

--- a/src/main/kotlin/bass/dto/tag/TagDTO.kt
+++ b/src/main/kotlin/bass/dto/tag/TagDTO.kt
@@ -1,0 +1,10 @@
+package bass.dto.tag
+
+data class TagDTO(
+    val id: Long = 0L,
+    val name: String,
+)
+
+data class CreateTagDTO(
+    val name: String,
+)

--- a/src/main/kotlin/bass/entities/TagEntity.kt
+++ b/src/main/kotlin/bass/entities/TagEntity.kt
@@ -1,0 +1,22 @@
+package bass.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "tag",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["name"])],
+)
+class TagEntity(
+    @Column(nullable = false)
+    val name: String,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : Auditable()

--- a/src/main/kotlin/bass/mappers/TagMapper.kt
+++ b/src/main/kotlin/bass/mappers/TagMapper.kt
@@ -1,0 +1,10 @@
+package bass.mappers
+
+import bass.dto.tag.TagDTO
+import bass.entities.TagEntity
+
+fun TagEntity.toDTO(): TagDTO =
+    TagDTO(
+        name = name,
+        id = this.id,
+    )

--- a/src/main/kotlin/bass/repositories/TagRepository.kt
+++ b/src/main/kotlin/bass/repositories/TagRepository.kt
@@ -1,0 +1,8 @@
+package bass.repositories
+
+import bass.entities.TagEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TagRepository : JpaRepository<TagEntity, Long> {
+    fun findByName(name: String): TagEntity?
+}

--- a/src/main/kotlin/bass/services/tag/TagServiceImpl.kt
+++ b/src/main/kotlin/bass/services/tag/TagServiceImpl.kt
@@ -1,0 +1,34 @@
+package bass.services.tag
+
+import bass.controller.tag.usecase.ManageTagUseCase
+import bass.dto.tag.CreateTagDTO
+import bass.dto.tag.TagDTO
+import bass.entities.TagEntity
+import bass.exception.NotFoundException
+import bass.mappers.toDTO
+import bass.repositories.TagRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TagServiceImpl(
+    private val tagRepository: TagRepository,
+) : ManageTagUseCase {
+    @Transactional(readOnly = true)
+    override fun findAll(): List<TagDTO> = tagRepository.findAll().map { it.toDTO() }
+
+    @Transactional(readOnly = true)
+    override fun findByName(name: String): TagEntity =
+        tagRepository.findByName(name) ?: throw NotFoundException("Tag with name: $name not found")
+
+    @Transactional
+    override fun create(tag: CreateTagDTO): TagDTO {
+        val existingTag = tagRepository.findByName(tag.name)
+        if (existingTag != null) {
+            throw IllegalStateException("Tag with name: ${tag.name} already exists")
+        }
+        val newTag = TagEntity(tag.name)
+        val savedTag = tagRepository.save(newTag)
+        return savedTag.toDTO()
+    }
+}

--- a/src/main/resources/db/changelog/changes/20250818-1600-create-tag.sql
+++ b/src/main/resources/db/changelog/changes/20250818-1600-create-tag.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tag
+(
+    id            BIGSERIAL PRIMARY KEY,
+    name          VARCHAR(50) NOT NULL,
+    created_at    TIMESTAMP   NOT NULL,
+    updated_at    TIMESTAMP   NOT NULL
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: changes/20250817-1700-create-coupon.sql
       relativeToChangelogFile: true
+  - include:
+      file: changes/20250818-1600-create-tag.sql
+      relativeToChangelogFile: true


### PR DESCRIPTION
# BASS APP

## Summary  
Added the `Tag` feature for categorization of meals. This includes entity setup, database migration, DTO mapping, service and controller layers, and a `/api/tags` endpoint to retrieve all tags.

* I was thinking if the `tags` should be assigned to the `Meal` and `Member` from the `Tag` service layer, but I think it would make more sense to be done by each of them respectively `Meal` and `Member`:

```
fun assignTagToMeal(mealId: Long, tagName: TagName): MealDTO
fun removeTagFromMeal(mealId: Long, tagName: TagName)

fun assignTagToMember(memberId: Long, tagName: TagName): MemberDTO
fun removeTagFromMember(memberId: Long, tagName: TagName)
```
* What do you think?

## Changes  
- Created `TagEntity` with enum values (`HEALTHY`, `NON_HEALTHY`)
- Created `TagDTO` and mapping functions
- Created `TagRepository` and `TagServiceImpl`
  - Implemented `findAll()` and `findByName(name: TagEntity.TagNames)` with `@Transactional(readOnly = true)`
- Created `TagController` with `/api/tags` GET endpoint
- Added Liquibase migration: `004-create-tag-table.sql`
- Updated `db.changelog-master.yaml` to include new tag changelog

## Checklist  
- [x] Code follows the style guide  
- [ ] Tests added or updated
- [ ] Documentation updated 
- [x] No console errors or warnings  
- [ ] (Optional) Assign reviewer  

## TODO
- [ ] Tests

## Related Issue  
#17 
