### PR TITLE
Config/OpenAPI with Swagger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ val assureVersion = "5.5.5"
 val h2Version = "2.2.224"
 val jwtVersion = "0.12.6"
 val dotenvVersion = "6.5.1"
+val openapiVersion = "2.8.9"
 val mockkVersion = "1.13.8"
 dependencies {
     implementation("org.liquibase:liquibase-core")
@@ -36,15 +37,20 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("io.github.cdimascio:dotenv-kotlin:$dotenvVersion")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$openapiVersion")
+
     runtimeOnly("com.h2database:h2:$h2Version")
     runtimeOnly("org.postgresql:postgresql")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:$jwtVersion")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jwtVersion")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.rest-assured:rest-assured:$assureVersion")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.mockk:mockk:$mockkVersion")
+
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,8 @@ spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 spring.liquibase.enabled=true
 spring.http.client.connect-timeout=5000
 spring.http.client.read-timeout=10000
+
+# default OpenAPI spec path
+springdoc.api-docs.path=/v3/api-docs
+# custom UI path with swagger-ui
+springdoc.swagger-ui.path=/api-docs


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
- Introduce an auto-generated API Documentation with Swagger-UI through `springdoc-openapi`

## Changes
- Add a dependency to apply `springdoc-openapi`
- Add configuration for `springdoc-openapi` in `application.properties`

## Screenshots
<!-- Add before/after screenshots or a quick GIF -->
<details><summary>screenshot of swagger page</summary>
<img width="611" height="3080" alt="localhost_swagger-ui_index html" src="https://github.com/user-attachments/assets/987cee8f-830f-477d-99dd-51dc4c869da4" />
</details>

## Checklist
- [x] Code follows the style guide
- [ ] ~~Tests added or updated~~ Not Applicable
- [x] Documentation updated
- [x] No console errors or warnings
- [x] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
#25 