### PR TITLE
feat: add the prod.dockerfile to create the image with docker compose…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -24,6 +24,7 @@ phases:
 artifacts:
   files:
     - build/libs/*.jar
+    - prod.dockerfile
     - docker-compose.prod.yml
     - appspec.yml
     - scripts/**/*


### PR DESCRIPTION
… on EC2

# BASS APP

## Summary
Fix the start.sh adding the prod.dockerfile to the ec2. docker compose now can create the image base in this dockerfile.

## Changes
- add prod.dockerfile inside the appspec.yml

## Screenshots / Demos (if applicable)
<!-- Add before/after screenshots or a quick GIF -->


## Checklist
- [x] Code follows the style guide
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #39 -->
Closes 39