### PR TITLE
feat: simplify the prod.dockerfile entrypoint to one line command

### DIFF
--- a/prod.dockerfile
+++ b/prod.dockerfile
@@ -13,27 +13,5 @@ EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=5s --start-period=15s \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 
-ENTRYPOINT exec java \                # Run Java as the main container process. "exec" replaces the shell
-                                      # with the Java process (PID 1) so signals (like SIGTERM) are delivered
-                                      # correctly for clean shutdown in Docker/Kubernetes.
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
 
-  -Xms512m \                          # Set the **initial Java heap size** to 512 MB.
-                                      # The JVM will start with this much memory allocated for the heap.
-
-  -Xmx1024m \                         # Set the **maximum Java heap size** to 1024 MB (1 GB).
-                                      # Prevents the JVM from consuming more than this much heap memory.
-
-  -XX:MaxMetaspaceSize=256m \         # Limit the **Metaspace** (where JVM stores class metadata) to 256 MB.
-                                      # Prevents class metadata from growing without bounds.
-
-  -XX:+UseG1GC \                      # Use the **G1 Garbage Collector**, good for low-latency,
-                                      # large heap applications. It's the modern default in new JVMs.
-
-  -XX:+HeapDumpOnOutOfMemoryError \   # Instructs the JVM to generate a **heap dump file** if
-                                      # an OutOfMemoryError occurs (useful for debugging).
-
-  -XX:HeapDumpPath=/app/heapdump.hprof \
-                                      # Location where the heap dump file will be written when OOM happens.
-
-  -jar /app/app.jar                   # Run the JAR file located at /app/app.jar.
-                                      # This is your Spring Boot (or other Java) application.


### PR DESCRIPTION
# BASS APP

## Summary
This pull request simplify the dockerfile entrypoint for only one line command to avoid possible parsing errors in aws.

## Changes

## Changes
- dockerfile


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #39 -->
Closes #39