### PR TITLE
feat: extend the period on healthcheck in the docker compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,8 +15,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 15s
+      retries: 5
+      start_period: 60s
 
   bass-green:
     build:
@@ -34,8 +34,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-      retries: 3
-      start_period: 15s
+      retries: 5
+      start_period: 60s
 
   db:
     image: postgres:15

--- a/prod.dockerfile
+++ b/prod.dockerfile
@@ -2,6 +2,8 @@ FROM eclipse-temurin:21-jdk-jammy
 
 RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
 
+RUN apt-get update && apt-get upgrade && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY ./build/libs/bass-0.0.1-SNAPSHOT.jar ./app.jar
@@ -9,9 +11,6 @@ COPY ./build/libs/bass-0.0.1-SNAPSHOT.jar ./app.jar
 USER appuser
 
 EXPOSE 8080
-
-HEALTHCHECK --interval=10s --timeout=5s --start-period=15s \
-  CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]
 


### PR DESCRIPTION

# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
extend the period on healthcheck in the docker compose file for the containers to match with ec2 performance

## Changes
- prod.dockerfile

## Screenshots / Demos (if applicable)
<!-- Add before/after screenshots or a quick GIF -->


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [ ] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #39 -->
Closes #39