### PR TITLE
Feat/create day entity

### DIFF
--- a/src/main/kotlin/bass/advice/ApiErrorControllerAdvice.kt
+++ b/src/main/kotlin/bass/advice/ApiErrorControllerAdvice.kt
@@ -5,6 +5,8 @@ import bass.dto.error.ErrorResponse
 import bass.exception.AuthorizationException
 import bass.exception.CouponAlreadyUsedException
 import bass.exception.CouponExpiredException
+import bass.exception.DayNameAlreadyExistsException
+import bass.exception.DaysSizeAlreadyMaximumException
 import bass.exception.ForbiddenException
 import bass.exception.InsufficientStockException
 import bass.exception.InvalidCartItemQuantityException
@@ -199,5 +201,21 @@ class ApiErrorControllerAdvice {
         val errorMessage = e.message ?: "Coupon expired"
         log.warn("CouponExpiredException: $errorMessage", e)
         return buildErrorResponse(HttpStatus.GONE, "Coupon expired", errorMessage)
+    }
+
+    @ExceptionHandler(DaysSizeAlreadyMaximumException::class)
+    fun handleDaysSizeAlreadyMaximumException(e: DaysSizeAlreadyMaximumException): ResponseEntity<ErrorResponse> {
+        val defaultMessage = "Days size for member already at maximum"
+        val errorMessage = e.message ?: defaultMessage
+        log.warn("DaysSizeAlreadyMaximumException: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.CONFLICT, defaultMessage, errorMessage)
+    }
+
+    @ExceptionHandler(DayNameAlreadyExistsException::class)
+    fun handleDayNameAlreadyExistsException(e: DayNameAlreadyExistsException): ResponseEntity<ErrorResponse> {
+        val defaultMessage = "Day name already exists"
+        val errorMessage = e.message ?: defaultMessage
+        log.warn("DayNameAlreadyExistsException: $errorMessage", e)
+        return buildErrorResponse(HttpStatus.CONFLICT, defaultMessage, errorMessage)
     }
 }

--- a/src/main/kotlin/bass/entities/DayEntity.kt
+++ b/src/main/kotlin/bass/entities/DayEntity.kt
@@ -1,0 +1,44 @@
+package bass.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "day_of_week")
+class DayEntity(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_name", nullable = false)
+    val dayName: DayOfWeek,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    var member: MemberEntity? = null,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+) : Auditable() {
+    enum class DayOfWeek {
+        MONDAY,
+        TUESDAY,
+        WEDNESDAY,
+        THURSDAY,
+        FRIDAY,
+        SATURDAY,
+        SUNDAY,
+    }
+
+    fun setMemberEntity(member: MemberEntity?) {
+        this.member = member
+        if (member != null && !member.days.contains(this)) {
+            member.days.add(this)
+        }
+    }
+}

--- a/src/main/kotlin/bass/exception/EcommerceExceptions.kt
+++ b/src/main/kotlin/bass/exception/EcommerceExceptions.kt
@@ -32,3 +32,7 @@ class InvalidTagNameException(message: String? = null) : RuntimeException(messag
 class CouponAlreadyUsedException(message: String? = null) : RuntimeException(message)
 
 class CouponExpiredException(message: String? = null) : RuntimeException(message)
+
+class DaysSizeAlreadyMaximumException(message: String? = null) : RuntimeException(message)
+
+class DayNameAlreadyExistsException(message: String? = null) : RuntimeException(message)

--- a/src/main/resources/db/changelog/changes/20250820-1600-create-day.sql
+++ b/src/main/resources/db/changelog/changes/20250820-1600-create-day.sql
@@ -3,6 +3,6 @@ CREATE TABLE day_of_week
      id           BIGSERIAL PRIMARY KEY,
      day_name     VARCHAR(20) NOT NULL,
      member_id    BIGINT      NOT NULL REFERENCES member (id),
-     created_at   TIMESTAMP   NOT NULL,
-     updated_at   TIMESTAMP   NOT NULL
+     created_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     updated_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/main/resources/db/changelog/changes/20250820-1600-create-day.sql
+++ b/src/main/resources/db/changelog/changes/20250820-1600-create-day.sql
@@ -1,0 +1,8 @@
+CREATE TABLE day_of_week
+(
+     id           BIGSERIAL PRIMARY KEY,
+     day_name     VARCHAR(20) NOT NULL,
+     member_id    BIGINT      NOT NULL REFERENCES member (id),
+     created_at   TIMESTAMP   NOT NULL,
+     updated_at   TIMESTAMP   NOT NULL
+);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -24,6 +24,9 @@ databaseChangeLog:
       file: changes/20250818-1850-create-join-tag-meal.sql
       relativeToChangelogFile: true
   - include:
+      file: changes/20250820-1600-create-day.sql
+      relativeToChangelogFile: true
+  - include:
       file: changes/20250820-1900-load-initial-data.yaml
       relativeToChangelogFile: true
   - include:

--- a/src/test/kotlin/bass/entities/MemberDayTest.kt
+++ b/src/test/kotlin/bass/entities/MemberDayTest.kt
@@ -1,0 +1,187 @@
+package bass.entities
+
+import bass.exception.DayNameAlreadyExistsException
+import bass.exception.DaysSizeAlreadyMaximumException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MemberDayTest {
+    @Test
+    fun `init - should NOT have more than 2 days`() {
+        // given
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        val dow2 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.FRIDAY,
+            )
+        val dow3 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.SATURDAY,
+            )
+        val newSet = mutableSetOf(dow1, dow2, dow3)
+
+        // when
+        // then
+        assertThrows<IllegalArgumentException> {
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+                days = newSet,
+            )
+        }
+    }
+
+    @Test
+    fun `addDay() - should the method sync collection`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+
+        // when
+        newMember.addDay(dow1)
+
+        // then
+        assertThat(newMember.days.first()).isEqualTo(dow1)
+        assertThat(dow1.member).isEqualTo(newMember)
+    }
+
+    @Test
+    fun `addDay() - should throw exception when add more than two days of day of week`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        val dow2 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.FRIDAY,
+            )
+        val dow3 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.SATURDAY,
+            )
+
+        // when
+        newMember.addDay(dow1)
+        newMember.addDay(dow2)
+
+        // then
+        assertThrows<DaysSizeAlreadyMaximumException> { newMember.addDay(dow3) }
+    }
+
+    @Test
+    fun `addDay() - should throw exception when add the same name of day of week that already added`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        val dow2 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        // when
+        newMember.addDay(dow1)
+
+        // then
+        assertThrows<DayNameAlreadyExistsException> { newMember.addDay(dow2) }
+    }
+
+    @Test
+    fun `removeDay() - should the method sync collection`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        newMember.addDay(dow1)
+
+        // when
+        newMember.removeDay(dow1)
+
+        // then
+        assertThat(newMember.days).isEmpty()
+        assertThat(dow1.member).isNull()
+    }
+
+    @Test
+    fun `removeDay() - assert when days is empty`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+
+        // when
+        // then
+        assertThrows<AssertionError> { newMember.removeDay(dow1) }
+    }
+
+    @Test
+    fun `removeDay() - assert when days do not have the name of the day`() {
+        // given
+        val newMember =
+            MemberEntity(
+                name = "New member",
+                email = "newmember@gmail.com",
+                password = "lalala",
+            )
+
+        val dow1 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.MONDAY,
+            )
+        val dow2 =
+            DayEntity(
+                dayName = DayEntity.DayOfWeek.SATURDAY,
+            )
+
+        // when
+        newMember.addDay(dow1)
+
+        // then
+        assertThrows<AssertionError> { newMember.removeDay(dow2) }
+    }
+}


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
- Introduce `DayEntity` with update on change log for sql.
- Apply `DayEntity` to `MemberEntity` with syncing methods to resolve relationship between two entities.

## Changes
- apply 'DayEntity' to 'MemberEntity' and introduce methods for 'days'
- register exception handlers for 'days' property in 'MemberEntity'
- add exceptions for 'days' handled in 'MemberEntity'
- register new sql file for creation of 'day_of_week' table
- add new sql file to create 'day_of_week' table for 'DayEntity'
- introduce 'DayEntity' to handle freedom-day setting for member

## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
Closes #21 