### PR TITLE
config: add CORS mappings for swagger-ui and h2 for dev environment

### DIFF
--- a/src/main/kotlin/bass/config/WebMvcConfiguration.kt
+++ b/src/main/kotlin/bass/config/WebMvcConfiguration.kt
@@ -33,5 +33,17 @@ class WebMvcConfiguration(
             .allowedHeaders("*")
             .exposedHeaders(HttpHeaders.LOCATION)
             .maxAge(3600)
+        registry.addMapping("/swagger-ui/**")
+            .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .exposedHeaders(HttpHeaders.LOCATION)
+            .maxAge(3600)
+        registry.addMapping("/h2/**")
+            .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .exposedHeaders(HttpHeaders.LOCATION)
+            .maxAge(3600)
     }
 }


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
Add two new CORS mapping those for swagger-ui and for h2 (dev only).

## Changes
- Update on `WebMvcConfiguration` to register new CORS mapping


## Checklist
- [x] Code follows the style guide
- [ ] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [x] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
