### PR TITLE
refactor: extend limit of meal (product) name size from 15 to 50

### DIFF
--- a/src/main/kotlin/bass/dto/meal/MealPatchDTO.kt
+++ b/src/main/kotlin/bass/dto/meal/MealPatchDTO.kt
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size
 import java.math.BigDecimal
 
 data class MealPatchDTO(
-    @field:Size(min = 1, max = 15, message = ValidationMessages.PRODUCT_NAME_SIZE)
+    @field:Size(min = 1, max = 50, message = ValidationMessages.PRODUCT_NAME_SIZE)
     @field:Pattern(regexp = "^[a-zA-Z0-9 ()\\[\\]+\\-&/_]*$", message = ValidationMessages.NAME_PATTERN)
     var name: String? = null,
     @field:Positive(message = ValidationMessages.PRICE_POSITIVE)

--- a/src/main/kotlin/bass/dto/meal/MealRequestDTO.kt
+++ b/src/main/kotlin/bass/dto/meal/MealRequestDTO.kt
@@ -11,7 +11,7 @@ import java.math.BigDecimal
 
 data class MealRequestDTO(
     @field:NotBlank(message = ValidationMessages.NAME_REQUIRED)
-    @field:Size(min = 1, max = 15, message = ValidationMessages.PRODUCT_NAME_SIZE)
+    @field:Size(min = 1, max = 50, message = ValidationMessages.PRODUCT_NAME_SIZE)
     @field:Pattern(regexp = "^[a-zA-Z0-9 ()\\[\\]+\\-&/_]*$", message = ValidationMessages.NAME_PATTERN)
     var name: String,
     @field:NotNull(message = ValidationMessages.PRICE_REQUIRED)

--- a/src/main/kotlin/bass/util/ValidationMessages.kt
+++ b/src/main/kotlin/bass/util/ValidationMessages.kt
@@ -4,7 +4,7 @@ package bass.util
 object ValidationMessages {
     const val NAME_REQUIRED = "Product name cannot be blank"
     const val PRICE_REQUIRED = "Price cannot be null"
-    const val PRODUCT_NAME_SIZE = "The product name must contain between 1 and 15 characters"
+    const val PRODUCT_NAME_SIZE = "The product name must contain between 1 and 50 characters"
     const val NAME_PATTERN = "Invalid characters in product name."
     const val PRICE_POSITIVE = "Price must be greater than zero"
     const val IMAGE_REQUIRED = "Image URL cannot be blank"

--- a/src/test/kotlin/bass/endtoend/MealE2ETest.kt
+++ b/src/test/kotlin/bass/endtoend/MealE2ETest.kt
@@ -3,6 +3,7 @@ package bass.endtoend
 import bass.dto.PageResponseDTO
 import bass.dto.meal.MealRequestDTO
 import bass.dto.meal.MealResponseDTO
+import bass.util.ValidationMessages
 import io.restassured.RestAssured
 import io.restassured.common.mapper.TypeRef
 import io.restassured.http.ContentType
@@ -176,7 +177,7 @@ class MealE2ETest {
     fun `Should return error when product name is bigger than 15 characters`() {
         val newMealDTO =
             MealRequestDTO(
-                name = "SpeakersareLovemyDearDearDear",
+                name = "SpeakersareLovemyDearDearDearThisIsVeryLongNameIHopeThisNameIsLongerThan50Chars",
                 price = 99.99.toBigDecimal(),
                 imageUrl = "https://example.com/speaker.jpg",
                 quantity = 4,
@@ -196,7 +197,7 @@ class MealE2ETest {
         assertThat(response.body().jsonPath().getInt("status")).isEqualTo(400)
         assertThat(
             response.body().jsonPath().getString("errors.find { it.field = 'name' }.message"),
-        ).isEqualTo("The product name must contain between 1 and 15 characters")
+        ).isEqualTo(ValidationMessages.PRODUCT_NAME_SIZE)
     }
 
     @Test


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
- refactor DTOs of `meal` to extend length size limit for name from 15 to 50

## Changes
- `MealPatchDTO` & `MealRequestDTO` - change max value for name field from 15 to 50.
- `util/ValidationMessages.kt` - update validation message
- `endtoend/MealE2ETest.kt` - edit test code to resolve the change


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
#110 