### PR TITLE
Feat/enhance event and order response

### DIFF
--- a/src/main/kotlin/bass/controller/member/usecase/CrudMemberUseCase.kt
+++ b/src/main/kotlin/bass/controller/member/usecase/CrudMemberUseCase.kt
@@ -1,5 +1,6 @@
 package bass.controller.member.usecase
 
+import bass.dto.member.MemberCouponDTO
 import bass.dto.member.MemberRegisterDTO
 import bass.model.Member
 
@@ -15,4 +16,6 @@ interface CrudMemberUseCase {
     fun deleteAll()
 
     fun validateEmailUniqueness(email: String)
+
+    fun findMemberNewAchievement(id: Long): MemberCouponDTO
 }

--- a/src/main/kotlin/bass/controller/order/OrderController.kt
+++ b/src/main/kotlin/bass/controller/order/OrderController.kt
@@ -1,8 +1,9 @@
 package bass.controller.order
 
 import bass.annotation.LoginMember
+import bass.controller.member.usecase.CrudMemberUseCase
 import bass.controller.order.usecase.OrderCreationUseCase
-import bass.dto.OrderDTO
+import bass.dto.OrderCreationResponseDTO
 import bass.dto.member.MemberLoginDTO
 import bass.model.PaymentRequest
 import org.springframework.http.ResponseEntity
@@ -13,13 +14,22 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/order")
-class OrderController(private val orderCreationUseCase: OrderCreationUseCase) {
+class OrderController(
+    private val orderCreationUseCase: OrderCreationUseCase,
+    private val crudMemberUseCase: CrudMemberUseCase,
+) {
     @PostMapping
     fun createOrder(
         @LoginMember member: MemberLoginDTO,
         @RequestBody paymentRequest: PaymentRequest,
-    ): ResponseEntity<OrderDTO> {
+    ): ResponseEntity<OrderCreationResponseDTO> {
         val order = orderCreationUseCase.create(member, paymentRequest)
-        return ResponseEntity.ok(order)
+        val memberWithAchievement = crudMemberUseCase.findMemberNewAchievement(member.id)
+        val response =
+            OrderCreationResponseDTO(
+                order = order,
+                memberDetails = memberWithAchievement,
+            )
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/bass/dto/OrderCreationResponseDTO.kt
+++ b/src/main/kotlin/bass/dto/OrderCreationResponseDTO.kt
@@ -1,0 +1,8 @@
+package bass.dto
+
+import bass.dto.member.MemberCouponDTO
+
+data class OrderCreationResponseDTO(
+    val order: OrderDTO,
+    val memberDetails: MemberCouponDTO,
+)

--- a/src/main/kotlin/bass/dto/coupon/CouponOrderDTO.kt
+++ b/src/main/kotlin/bass/dto/coupon/CouponOrderDTO.kt
@@ -1,0 +1,7 @@
+package bass.dto.coupon
+
+data class CouponOrderDTO(
+    val displayName: String,
+    val memberStreak: Int,
+    val achievementDescription: String,
+)

--- a/src/main/kotlin/bass/dto/member/MemberCouponDTO.kt
+++ b/src/main/kotlin/bass/dto/member/MemberCouponDTO.kt
@@ -1,0 +1,8 @@
+package bass.dto.member
+
+import bass.dto.coupon.CouponOrderDTO
+
+class MemberCouponDTO(
+    val memberId: Long,
+    val newCoupon: CouponOrderDTO? = null,
+)

--- a/src/main/kotlin/bass/mappers/CouponMapper.kt
+++ b/src/main/kotlin/bass/mappers/CouponMapper.kt
@@ -1,6 +1,7 @@
 package bass.mappers
 
 import bass.dto.coupon.CouponDTO
+import bass.dto.coupon.CouponOrderDTO
 import bass.entities.CouponEntity
 
 fun CouponEntity.toDTO() =
@@ -15,3 +16,11 @@ fun CouponEntity.toDTO() =
         expiresAt = expiresAt,
         id = id,
     )
+
+fun CouponEntity.toOrderDTO(): CouponOrderDTO {
+    return CouponOrderDTO(
+        displayName = this.achievement.name,
+        memberStreak = this.member.streak,
+        achievementDescription = this.achievement.description,
+    )
+}

--- a/src/main/kotlin/bass/mappers/MemberMapper.kt
+++ b/src/main/kotlin/bass/mappers/MemberMapper.kt
@@ -1,10 +1,13 @@
 package bass.mappers
 
+import bass.dto.member.MemberCouponDTO
 import bass.dto.member.MemberLoginDTO
 import bass.dto.member.MemberRegisterDTO
 import bass.entities.MemberEntity
 import bass.entities.TagEntity
 import bass.model.Member
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 fun MemberEntity.toDTO() = Member(name, email, password, role, id)
 
@@ -18,5 +21,19 @@ fun MemberRegisterDTO.toEntity(tags: Set<TagEntity>): MemberEntity {
         email = this.email,
         password = this.password,
         tags = tags.toMutableSet(),
+    )
+}
+
+fun MemberEntity.toOrderDTO(): MemberCouponDTO {
+    val fifteenMinutesAgo = Instant.now().minus(15, ChronoUnit.MINUTES)
+    val recentCouponDTO =
+        this.coupons
+            .lastOrNull()
+            ?.takeIf { it.createdAt.isAfter(fifteenMinutesAgo) }
+            ?.toOrderDTO()
+
+    return MemberCouponDTO(
+        memberId = this.id,
+        newCoupon = recentCouponDTO,
     )
 }

--- a/src/main/kotlin/bass/services/member/MemberServiceImpl.kt
+++ b/src/main/kotlin/bass/services/member/MemberServiceImpl.kt
@@ -1,10 +1,12 @@
 package bass.services.member
 
 import bass.controller.member.usecase.CrudMemberUseCase
+import bass.dto.member.MemberCouponDTO
 import bass.dto.member.MemberRegisterDTO
 import bass.exception.OperationFailedException
 import bass.mappers.toDTO
 import bass.mappers.toEntity
+import bass.mappers.toOrderDTO
 import bass.model.Member
 import bass.repositories.MemberRepository
 import bass.repositories.TagRepository
@@ -54,5 +56,11 @@ class MemberServiceImpl(
         if (memberRepository.existsByEmail(email)) {
             throw OperationFailedException("Member with email '$email' already exists")
         }
+    }
+
+    override fun findMemberNewAchievement(id: Long): MemberCouponDTO {
+        val updatedMemberEntity = memberRepository.findById(id).get()
+        val memberOrderDTO = updatedMemberEntity.toOrderDTO()
+        return memberOrderDTO
     }
 }


### PR DESCRIPTION
# BASS APP

## Summary
This PR include the changes to create a new transaction in the Event Listener when placing an order.
Also improvements and changes in OrderController to include in the response if the member got a new achievement.

## Changes
- Add annotations in eventListener:
   - @Transactional(propagation = Propagation.REQUIRES_NEW)
   - @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
- Create DTOs for data about member (new achievement) and wrapper for Order and Member Response
- Create Mappers for new DTOs
- Create method in member service to get last achievement
- Adapt test to new response


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [ ] Documentation updated
- [x] No console errors

## Related Issue
 Closes #117
