### PR TITLE
fix: resolve issue from springdoc response with 500

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ val assureVersion = "5.5.5"
 val h2Version = "2.2.224"
 val jwtVersion = "0.12.6"
 val dotenvVersion = "6.5.1"
-val openapiVersion = "2.8.9"
+val openapiVersion = "2.8.0"
 val mockkVersion = "1.13.8"
 dependencies {
     implementation("org.liquibase:liquibase-core")


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
This PR is to resolve the issue from `springdoc` with swagger-ui responding with 500.

## Changes
- downgrade the version of `springdoc-openapi-starter-webmvc-ui` from 2.8.9 to 2.8.0


## Checklist
- [x] Code follows the style guide
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] No console errors or warnings
- [x] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
#121 