### PR TITLE
fix(natural_search): update meals type to MealResponseDTO

### DIFF
--- a/src/main/kotlin/bass/dto/NaturalSearchResponseDTO.kt
+++ b/src/main/kotlin/bass/dto/NaturalSearchResponseDTO.kt
@@ -1,10 +1,12 @@
 package bass.dto
 
+import bass.dto.meal.MealResponseDTO
 import bass.entities.MealEntity
+import bass.mappers.toDTO
 
 data class NaturalSearchResponseDTO(
     val selectedTags: List<String>,
-    val meals: List<MealEntity>,
+    val meals: List<MealResponseDTO>,
 ) {
     companion object {
         fun from(
@@ -13,7 +15,7 @@ data class NaturalSearchResponseDTO(
         ): NaturalSearchResponseDTO {
             return NaturalSearchResponseDTO(
                 selectedTags = tagInference.selectedTags,
-                meals = meals,
+                meals = meals.map { it.toDTO() },
             )
         }
     }


### PR DESCRIPTION
# Bass

## Summary
<!-- Briefly describe the changes and their purpose -->
This pull request updates how meal data is represented in the `NaturalSearchResponseDTO` class to improve API consistency and encapsulation. Instead of returning raw `MealEntity` objects, the response now returns a list of `MealResponseDTO` objects, ensuring that only the intended fields are exposed to API consumers.


## Changes
- Changed the `meals` property in `NaturalSearchResponseDTO` from a list of `MealEntity` to a list of `MealResponseDTO`, and updated the factory method to map entities to DTOs using `toDTO`. [[1]](diffhunk://#diff-84ff7f5262f0b4fc9fb5389a11bfa33ab740cf6693fd50b67a1a4f2ea9e95f29R3-R9) [[2]](diffhunk://#diff-84ff7f5262f0b4fc9fb5389a11bfa33ab740cf6693fd50b67a1a4f2ea9e95f29L16-R18)# BASS APP

## Screenshots / Demos (if applicable)
<!-- Add before/after screenshots or a quick GIF -->


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
