### PR TITLE
fix(member): memberEntity different to member as a model

### DIFF
--- a/src/main/kotlin/bass/config/resolvers/LoginMemberArgumentResolver.kt
+++ b/src/main/kotlin/bass/config/resolvers/LoginMemberArgumentResolver.kt
@@ -31,7 +31,7 @@ class LoginMemberArgumentResolver(
         val email =
             webRequest.getAttribute("email", RequestAttributes.SCOPE_REQUEST) as? String
                 ?: throw AuthorizationException("Email attribute missing")
-        return memberRepository.findByEmail(email)?.toDTO()?.toLoginDTO() ?: throw EmptyResultDataAccessException(
+        return memberRepository.findByEmail(email)?.toLoginDTO() ?: throw EmptyResultDataAccessException(
             "Member with Email $email not found",
             1,
         )

--- a/src/main/kotlin/bass/config/resolvers/LoginMemberArgumentResolver.kt
+++ b/src/main/kotlin/bass/config/resolvers/LoginMemberArgumentResolver.kt
@@ -2,7 +2,6 @@ package bass.config.resolvers
 
 import bass.annotation.LoginMember
 import bass.exception.AuthorizationException
-import bass.mappers.toDTO
 import bass.mappers.toLoginDTO
 import bass.repositories.MemberRepository
 import org.springframework.core.MethodParameter

--- a/src/main/kotlin/bass/controller/member/MemberController.kt
+++ b/src/main/kotlin/bass/controller/member/MemberController.kt
@@ -9,10 +9,7 @@ import bass.dto.member.MemberRegisterDTO
 import bass.dto.token.TokenRequestDTO
 import bass.dto.token.TokenResponseDTO
 import bass.infrastructure.AuthorizationExtractor
-import bass.mappers.toProfileDTO
 import bass.model.Member
-import bass.services.achievement.AchievementServiceImpl
-import bass.services.coupon.CouponServiceImpl
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -26,8 +23,6 @@ class MemberController(
     private val authService: AuthUseCase,
     private val authorizationExtractor: AuthorizationExtractor,
     private val crudMemberUseCase: CrudMemberUseCase,
-    private val achievementService: AchievementServiceImpl,
-    private val couponServiceImpl: CouponServiceImpl,
 ) {
     @PostMapping(MEMBERS_PATH_REGISTER)
     fun register(

--- a/src/main/kotlin/bass/controller/member/MemberController.kt
+++ b/src/main/kotlin/bass/controller/member/MemberController.kt
@@ -57,15 +57,8 @@ class MemberController(
     fun findMyProfile(
         @LoginMember memberLoginDTO: MemberLoginDTO,
     ): ResponseEntity<MemberProfileDTO> {
-        val member = crudMemberUseCase.findById(memberLoginDTO.id)
-        val achievements = achievementService.findAllByMemberId(member.id)
-        val coupons = couponServiceImpl.findAll(member.id)
-        return ResponseEntity.ok().body(
-            member.toProfileDTO(
-                achievements = achievements,
-                coupons = coupons,
-            ),
-        )
+        val member = crudMemberUseCase.findByIdToProfile(memberLoginDTO.id)
+        return ResponseEntity.ok().body(member)
     }
 
     companion object {

--- a/src/main/kotlin/bass/controller/member/usecase/CrudMemberUseCase.kt
+++ b/src/main/kotlin/bass/controller/member/usecase/CrudMemberUseCase.kt
@@ -1,6 +1,7 @@
 package bass.controller.member.usecase
 
 import bass.dto.member.MemberCouponDTO
+import bass.dto.member.MemberProfileDTO
 import bass.dto.member.MemberRegisterDTO
 import bass.model.Member
 
@@ -18,4 +19,6 @@ interface CrudMemberUseCase {
     fun validateEmailUniqueness(email: String)
 
     fun findMemberNewAchievement(id: Long): MemberCouponDTO
+
+    fun findByIdToProfile(id: Long): MemberProfileDTO
 }

--- a/src/main/kotlin/bass/dto/member/MemberProfileDTO.kt
+++ b/src/main/kotlin/bass/dto/member/MemberProfileDTO.kt
@@ -13,5 +13,5 @@ data class MemberProfileDTO(
     val testimonial: String,
     var coupons: List<CouponDTO>,
     var tags: List<TagDTO>,
-    var days: List<DayDTO>
+    var days: List<DayDTO>,
 )

--- a/src/main/kotlin/bass/dto/member/MemberProfileDTO.kt
+++ b/src/main/kotlin/bass/dto/member/MemberProfileDTO.kt
@@ -2,6 +2,8 @@ package bass.dto.member
 
 import bass.dto.achievement.AchievementDTO
 import bass.dto.coupon.CouponDTO
+import bass.dto.day.DayDTO
+import bass.dto.tag.TagDTO
 
 data class MemberProfileDTO(
     var name: String,
@@ -10,4 +12,6 @@ data class MemberProfileDTO(
     var achievements: List<AchievementDTO>,
     val testimonial: String,
     var coupons: List<CouponDTO>,
+    var tags: List<TagDTO>,
+    var days: List<DayDTO>
 )

--- a/src/main/kotlin/bass/mappers/MemberMapper.kt
+++ b/src/main/kotlin/bass/mappers/MemberMapper.kt
@@ -1,7 +1,6 @@
 package bass.mappers
 
 import bass.dto.achievement.AchievementDTO
-import bass.dto.coupon.CouponDTO
 import bass.dto.member.MemberCouponDTO
 import bass.dto.member.MemberLoginDTO
 import bass.dto.member.MemberProfileDTO
@@ -32,7 +31,7 @@ fun MemberEntity.toDTO(): Member {
 
 fun MemberEntity.toLoginDTO() = MemberLoginDTO(id)
 
-fun MemberEntity.toEntity() = MemberEntity(name, email, password, role, id = id)
+fun Member.toEntity() = MemberEntity(name, email, password, role, id = id)
 
 fun MemberRegisterDTO.toEntity(
     tags: Set<TagEntity>,
@@ -74,6 +73,6 @@ fun MemberEntity.toProfileDTO(
         testimonial = this.testimonial,
         coupons = coupons.map { it.toDTO() },
         tags = this.tags.map { it.toDTO() },
-        days = this.days.map { it.toDTO()},
+        days = this.days.map { it.toDTO() },
     )
 }

--- a/src/main/kotlin/bass/mappers/MemberMapper.kt
+++ b/src/main/kotlin/bass/mappers/MemberMapper.kt
@@ -6,6 +6,8 @@ import bass.dto.member.MemberCouponDTO
 import bass.dto.member.MemberLoginDTO
 import bass.dto.member.MemberProfileDTO
 import bass.dto.member.MemberRegisterDTO
+import bass.entities.AchievementEntity
+import bass.entities.CouponEntity
 import bass.entities.DayEntity
 import bass.entities.MemberEntity
 import bass.entities.TagEntity
@@ -28,9 +30,9 @@ fun MemberEntity.toDTO(): Member {
     )
 }
 
-fun Member.toLoginDTO() = MemberLoginDTO(id)
+fun MemberEntity.toLoginDTO() = MemberLoginDTO(id)
 
-fun Member.toEntity() = MemberEntity(name, email, password, role, id = id)
+fun MemberEntity.toEntity() = MemberEntity(name, email, password, role, id = id)
 
 fun MemberRegisterDTO.toEntity(
     tags: Set<TagEntity>,
@@ -60,16 +62,18 @@ fun MemberEntity.toOrderDTO(): MemberCouponDTO {
     )
 }
 
-fun Member.toProfileDTO(
-    achievements: List<AchievementDTO>,
-    coupons: List<CouponDTO>,
+fun MemberEntity.toProfileDTO(
+    achievements: List<AchievementEntity>,
+    coupons: List<CouponEntity>,
 ): MemberProfileDTO {
     return MemberProfileDTO(
         name = this.name,
         email = this.email,
         streak = this.streak,
-        achievements = achievements,
+        achievements = achievements.map { AchievementDTO.fromEntity(it) },
         testimonial = this.testimonial,
-        coupons = coupons,
+        coupons = coupons.map { it.toDTO() },
+        tags = this.tags.map { it.toDTO() },
+        days = this.days.map { it.toDTO()},
     )
 }

--- a/src/main/kotlin/bass/services/cart/CartItemServiceImpl.kt
+++ b/src/main/kotlin/bass/services/cart/CartItemServiceImpl.kt
@@ -10,6 +10,7 @@ import bass.mappers.toDTO
 import bass.mappers.toEntity
 import bass.repositories.CartItemRepository
 import bass.repositories.MealRepository
+import bass.repositories.MemberRepository
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -21,6 +22,7 @@ class CartItemServiceImpl(
     private val cartItemRepository: CartItemRepository,
     private val mealRepository: MealRepository,
     private val memberService: CrudMemberUseCase,
+    private val memberRepository: MemberRepository,
 ) : ManageCartItemUseCase {
     @Transactional
     override fun addOrUpdate(
@@ -81,10 +83,10 @@ class CartItemServiceImpl(
             mealRepository.findByIdOrNull(cartItemRequestDTO.mealId)
                 ?: throw OperationFailedException("Invalid Product Id ${cartItemRequestDTO.mealId}")
         option.checkStock(cartItemRequestDTO.quantity)
-        val member = memberService.findById(memberId)
+        val member = memberRepository.findByIdOrNull(memberId)!!
         return cartItemRepository.save(
             CartItemEntity(
-                member = member.toEntity(),
+                member = member,
                 meal = option,
                 quantity = cartItemRequestDTO.quantity,
                 addedAt = Instant.now(),

--- a/src/main/kotlin/bass/services/cart/CartItemServiceImpl.kt
+++ b/src/main/kotlin/bass/services/cart/CartItemServiceImpl.kt
@@ -1,13 +1,11 @@
 package bass.services.cart
 
 import bass.controller.cart.usecase.ManageCartItemUseCase
-import bass.controller.member.usecase.CrudMemberUseCase
 import bass.dto.cartItem.CartItemRequestDTO
 import bass.dto.cartItem.CartItemResponseDTO
 import bass.entities.CartItemEntity
 import bass.exception.OperationFailedException
 import bass.mappers.toDTO
-import bass.mappers.toEntity
 import bass.repositories.CartItemRepository
 import bass.repositories.MealRepository
 import bass.repositories.MemberRepository
@@ -21,7 +19,6 @@ import java.time.Instant
 class CartItemServiceImpl(
     private val cartItemRepository: CartItemRepository,
     private val mealRepository: MealRepository,
-    private val memberService: CrudMemberUseCase,
     private val memberRepository: MemberRepository,
 ) : ManageCartItemUseCase {
     @Transactional


### PR DESCRIPTION
# BASS APP

## Summary
<!-- Briefly describe the changes and their purpose -->
This pull request refactors the member profile retrieval logic and improves type usage and mapping in the member-related services and DTOs. The main changes include moving profile assembly into the service layer, updating DTOs to include more fields, and standardizing mapper functions to work directly with entities. These updates enhance maintainability and ensure that profile data is consistently constructed.

## Changes
**DTO and mapping improvements:**
* Expanded `MemberProfileDTO` to include `tags` and `days` fields, allowing for richer member profile information.
* Updated `MemberMapper.toProfileDTO` to accept and map entity lists for achievements, coupons, tags, and days, ensuring consistent conversion to DTOs.

**Repository and dependency updates:**
* Added `AchievementRepository` and `CouponRepository` as dependencies to `MemberServiceImpl` to support profile data retrieval.
* Updated `CartItemServiceImpl` to use `MemberRepository.findByIdOrNull` for member lookup, removing unnecessary conversion and ensuring correct entity usage.

**Type and method standardization:**
* Changed mapper functions (`toLoginDTO`, `toEntity`) to operate directly on `MemberEntity` instead of intermediate DTOs, simplifying data flow.

These changes collectively improve the clarity, maintainability, and extensibility of member profile handling in the codebase.

## Screenshots / Demos (if applicable)
<!-- Add before/after screenshots or a quick GIF -->


## Checklist
- [x] Code follows the style guide
- [x] Tests added or updated
- [x] Documentation updated
- [x] No console errors or warnings
- [ ] (Optional) Assign reviewer

## Related Issue
<!-- Link to issue: Closes #123 -->
